### PR TITLE
Create new argocd deploy to foo

### DIFF
--- a/applications/application-foo.yaml
+++ b/applications/application-foo.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: foo
+  namespace: argocd
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    namespace: default
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: ./kubernetes/production
+    repoURL: https://github.com/carioca-org/foo.git
+    targetRevision: HEAD
+  syncPolicy:
+    automated:
+      prune: true
+      allowEmpty: true


### PR DESCRIPTION
# New application module in ArgoCD
 This pull request create new deploy AplicationSet **foo** in ArgoCD Cluster 

 Please be informed that the provisioning time for the ArgoCD cluster may take from a few minutes to about an hour to be completed. 
 However, it is important to note that this time may vary depending on the specifications of your cluster. 
 We kindly suggest that you monitor the status of your cluster on the AWS interface to obtain up-to-date information on the provisioning process. 
 Should you have any inquiries or require further assistance, please do not hesitate to contact our SRE team.

 Thank you for your attention.
